### PR TITLE
Adds type annotations within the .ml files in addition to .mli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # assignment
-enigma.zip
+chess.zip
 
 # ocaml
 *.cmo

--- a/src/game.ml
+++ b/src/game.ml
@@ -27,9 +27,10 @@ type properties = {
   h_rook_moved : bool;
 }
 
-let update_board bd mv = raise (Failure "Unimplemented")
+let update_board (bd : t) (mv : move) : t =
+  raise (Failure "Unimplemented")
 
-let load_game j = raise (Failure "Unimplemented")
+let load_game (j : Yojson.Basic.t) = raise (Failure "Unimplemented")
 
 (**********************************************************************
  * SOLDIER LOGIC:

--- a/src/game.ml
+++ b/src/game.ml
@@ -49,7 +49,8 @@ module type SoldierLogic = sig
 end
 
 module Pawn : SoldierLogic = struct
-  let legal_moves prop coords = raise (Failure "Unimplemented")
+  let legal_moves (prop : properties) (coords : int * int) : move list =
+    raise (Failure "Unimplemented")
 end
 
 module Knight : SoldierLogic = struct
@@ -69,25 +70,29 @@ module Knight : SoldierLogic = struct
 
   (* Right now, this only returns the knight moves that are on the board
      and do not move to a square with a same color piece on it. *)
-  let legal_moves prop coords =
+  let legal_moves (prop : properties) (coords : int * int) : move list =
     let board = board_to_array prop.board in
     squares_to_moves coords (potential_squares coords board prop.color)
 end
 
 module Bishop : SoldierLogic = struct
-  let legal_moves prop coords = raise (Failure "Unimplemented")
+  let legal_moves (prop : properties) (coords : int * int) : move list =
+    raise (Failure "Unimplemented")
 end
 
 module Rook : SoldierLogic = struct
-  let legal_moves prop coords = raise (Failure "Unimplemented")
+  let legal_moves (prop : properties) (coords : int * int) : move list =
+    raise (Failure "Unimplemented")
 end
 
 module Queen : SoldierLogic = struct
-  let legal_moves prop coords = raise (Failure "Unimplemented")
+  let legal_moves (prop : properties) (coords : int * int) : move list =
+    raise (Failure "Unimplemented")
 end
 
 module King : SoldierLogic = struct
-  let legal_moves prop coords = raise (Failure "Unimplemented")
+  let legal_moves (prop : properties) (coords : int * int) : move list =
+    raise (Failure "Unimplemented")
 end
 
 (* ASSUMPTION FOR THE FOLLOWING FUNCTIONS: A board is a 2d list of

--- a/src/state.ml
+++ b/src/state.ml
@@ -4,6 +4,8 @@ type t = {
   turn : bool;
 }
 
-let init_state board color = raise (Failure "Unimplemented")
+let init_state (board : Game.t) (color : Game.color) : t =
+  raise (Failure "Unimplemented")
 
-let play_move st move = raise (Failure "Unimplemented")
+let play_move (st : t) (move : Game.move) : t =
+  raise (Failure "Unimplemented")


### PR DESCRIPTION
For clarity while working in the .ml files, I've added actual types annotations so that it's much clearer and that we do not see something like "'a -> 'b -> 'c" and have the actual specifics. Just makes it easier as we are working on these files over the course of months and that we have four team members. 