### PR TITLE
Implemented the pin checker. Drops any legal moves if true for a piece.

### DIFF
--- a/src/helper.ml
+++ b/src/helper.ml
@@ -8,6 +8,13 @@
     2d list to a 2d array.*)
 let board_to_array board = Array.of_list (List.map Array.of_list board)
 
+(** [array_to_board board_arr] converts the array representation of a
+    board to a list representation, where each column is now a list,
+    joined together in a larger list. In other words, this converts a 2d
+    array to a 2d list.*)
+let array_to_board board_arr =
+  Array.to_list (Array.map Array.to_list board_arr)
+
 (** [on_board (x, y)] is true if [x] and [y] are in 0..7 inclusive. *)
 let on_board (x, y) = x >= 0 && x <= 7 && y >= 0 && y <= 7
 

--- a/src/state.ml
+++ b/src/state.ml
@@ -2,6 +2,9 @@ type t = {
   game_state : Game.properties;
   moves : Game.move list;
   turn : bool;
+  a_rook_moved : bool;
+  h_rook_moved : bool;
+  king_moved : bool;
 }
 
 let init_state (board : Game.t) (color : Game.color) : t =

--- a/src/state.mli
+++ b/src/state.mli
@@ -14,6 +14,12 @@ type t = {
     played, we set this to false, and back to true when we receive a
     move from the opponent.*)
   turn : bool;
+  (*True if the starting rook on the A file has moved.*)
+  a_rook_moved : bool;
+  (*True if the starting rook on the H file has moved.*)
+  h_rook_moved : bool;
+  (*True if the king has moved.*)
+  king_moved : bool;
 }
 
 val init_state : Game.t -> Game.color -> t


### PR DESCRIPTION
The pin checker works by removing the piece from the board, then calculating the legal moves for the opponent in that new position, and then checking if our king is attacked by those enemy moves. If a piece is found to be pinned, it will return no legal moves. 

The only way to order these functions and use a pin checker is if it is passed in as a parameter. I made it an optional argument to legal_moves, with the default being a pin checker that always returns false. This default case is useful when determining the legal moves for the opponent when the piece is removed because we can be attacked by a piece that is pinned, therefore every enemy piece can be viewed as not pinned.

I also moved king_moved, A_rook_moved, and H_rook_moved out to state so that we can have a castling detection function that takes those in and sets a flag in Game.properties (kingside_castle and queenside_castle).

King_in_check will be used later to add an additional filter to legal moves for blocking checks.