### PR TITLE
Implemented move checker to find legal moves in check.

### DIFF
--- a/src/game.ml
+++ b/src/game.ml
@@ -49,12 +49,16 @@ module type SoldierLogic = sig
     properties ->
     int * int ->
     (properties -> int * int -> bool) ->
+    (properties -> move -> bool) ->
     move list
 end
 
 module Pawn : SoldierLogic = struct
-  let legal_moves (prop : properties) (coords : int * int) pin_checker :
-      move list =
+  let legal_moves
+      (prop : properties)
+      (coords : int * int)
+      pin_checker
+      move_checker : move list =
     if pin_checker prop coords then []
     else raise (Failure "Unimplemented")
 end
@@ -79,34 +83,48 @@ module Knight : SoldierLogic = struct
         (x - 1, y - 2);
       ]
 
-  (* Right now, this only returns the knight moves that are on the board
-     and do not move to a square with a same color piece on it. *)
-  let legal_moves (prop : properties) (coords : int * int) pin_checker :
-      move list =
+  let legal_moves
+      (prop : properties)
+      (coords : int * int)
+      pin_checker
+      move_checker : move list =
     if pin_checker prop coords then []
     else
       let board = board_to_array prop.board in
-      squares_to_moves coords
-        (potential_squares coords board prop.color)
+      let moves =
+        squares_to_moves coords
+          (potential_squares coords board prop.color)
+      in
+      if prop.king_in_check then List.filter (move_checker prop) moves
+      else moves
 end
 
 module Bishop : SoldierLogic = struct
-  let legal_moves (prop : properties) (coords : int * int) pin_checker :
-      move list =
+  let legal_moves
+      (prop : properties)
+      (coords : int * int)
+      pin_checker
+      move_checker : move list =
     if pin_checker prop coords then []
     else raise (Failure "Unimplemented")
 end
 
 module Rook : SoldierLogic = struct
-  let legal_moves (prop : properties) (coords : int * int) pin_checker :
-      move list =
+  let legal_moves
+      (prop : properties)
+      (coords : int * int)
+      pin_checker
+      move_checker : move list =
     if pin_checker prop coords then []
     else raise (Failure "Unimplemented")
 end
 
 module Queen : SoldierLogic = struct
-  let legal_moves (prop : properties) (coords : int * int) pin_checker :
-      move list =
+  let legal_moves
+      (prop : properties)
+      (coords : int * int)
+      pin_checker
+      move_checker : move list =
     if pin_checker prop coords then []
     else raise (Failure "Unimplemented")
 end
@@ -142,8 +160,8 @@ module King : SoldierLogic = struct
     | false, true -> [ (x - 2, y) ]
     | false, false -> []
 
-  let legal_moves (prop : properties) (coords : int * int) _ : move list
-      =
+  let legal_moves (prop : properties) (coords : int * int) _ _ :
+      move list =
     let board = board_to_array prop.board in
     let castle_append = castle_squares prop coords in
     let not_attacked square =
@@ -170,30 +188,39 @@ end
     column. If a piece is considered pinned by [pin_checker], then no
     moves will be returned for that piece. Requires: [x] and [y] are in
     0..7.*)
-let rec moves_for_column prop (x, y) pin_checker = function
+let rec moves_for_column prop (x, y) pin_checker move_checker = function
   | [] -> []
-  | None :: t -> moves_for_column prop (x, y + 1) pin_checker t
+  | None :: t ->
+      moves_for_column prop (x, y + 1) pin_checker move_checker t
   | Some (color, soldier) :: t ->
       if color <> prop.color then
-        moves_for_column prop (x, y + 1) pin_checker t
+        moves_for_column prop (x, y + 1) pin_checker move_checker t
       else
         begin
           begin
             match soldier with
-            | Pawn -> Pawn.legal_moves prop (x, y) pin_checker
-            | Knight -> Knight.legal_moves prop (x, y) pin_checker
-            | Bishop -> Bishop.legal_moves prop (x, y) pin_checker
-            | Rook -> Rook.legal_moves prop (x, y) pin_checker
-            | Queen -> Queen.legal_moves prop (x, y) pin_checker
-            | King -> King.legal_moves prop (x, y) pin_checker
+            | Pawn ->
+                Pawn.legal_moves prop (x, y) pin_checker move_checker
+            | Knight ->
+                Knight.legal_moves prop (x, y) pin_checker move_checker
+            | Bishop ->
+                Bishop.legal_moves prop (x, y) pin_checker move_checker
+            | Rook ->
+                Rook.legal_moves prop (x, y) pin_checker move_checker
+            | Queen ->
+                Queen.legal_moves prop (x, y) pin_checker move_checker
+            | King ->
+                King.legal_moves prop (x, y) pin_checker move_checker
           end
-          @ moves_for_column prop (x, y + 1) pin_checker t
+          @ moves_for_column prop (x, y + 1) pin_checker move_checker t
         end
 
-let legal_moves ?pin_checker:(pc = fun _ _ -> false) (prop : properties)
-    =
+let legal_moves
+    ?pin_checker:(pc = fun _ _ -> false)
+    ?move_checker:(mc = fun _ _ -> true)
+    (prop : properties) =
   let column_handler (lst, col_num) column =
-    (lst @ moves_for_column prop (col_num, 0) pc column, col_num + 1)
+    (lst @ moves_for_column prop (col_num, 0) pc mc column, col_num + 1)
   in
   fst (List.fold_left column_handler ([], 0) prop.board)
 
@@ -212,3 +239,17 @@ let pin_checker (prop : properties) (x, y) : bool =
          king_in_check = false;
        })
     prop.king_pos
+
+let move_checker (prop : properties) (mv : move) : bool =
+  let new_board = update_board prop.board mv in
+  let enemy_color = if prop.color = White then Black else White in
+  not
+    (is_attacked
+       (legal_moves
+          {
+            prop with
+            board = new_board;
+            color = enemy_color;
+            king_in_check = false;
+          })
+       prop.king_pos)

--- a/src/game.mli
+++ b/src/game.mli
@@ -60,17 +60,26 @@ val pin_checker : properties -> int * int -> bool
     piece is removed from the board. Requires: [coords] is on the board
     and is a piece of the color specified in [prop].*)
 
+val move_checker : properties -> move -> bool
+(** [pin_checker mv] is true if [mv] does not put the king of the side
+    specificed by [prop] in check. Requires: [mv] is not a king move.*)
+
 val legal_moves :
   ?pin_checker:(properties -> int * int -> bool) ->
+  ?move_checker:(properties -> move -> bool) ->
   properties ->
   move list
-(** [legal_moves prop pin_checker] is a list of legal moves with [prop]
-    providing context to the position and specifying the color to output
-    moves for. If [pin_checker] is provided, all pieces will be checked
-    to see if they are pinned with its logic, and if so, will return no
-    legal moves (a piece is pinned if it cannot move because the same
-    color king will be attacked). By default, [pin_checker] will treat
-    every piece as not pinned.*)
+(** [legal_moves pin_checker move_checker prop] is a list of legal moves
+    with [prop] providing context to the position and specifying the
+    color to output moves for. If [pin_checker] is provided, all pieces
+    will be checked to see if they are pinned with its logic, and if so,
+    will return no legal moves (a piece is pinned if it cannot move
+    because the same color king will be attacked). By default,
+    [pin_checker] will treat every piece as not pinned. If
+    [move_checker] is provided, it will return only the moves of
+    unpinned pieces that do not put the king in check. By default,
+    [move_checker] will treat every move as not putting the king in
+    check.*)
 
 (**[SoldierLogic] defines the interface for each piece to determine the
    legal moves for that piece. Requires: the piece at [coords] is of the
@@ -84,6 +93,7 @@ module type SoldierLogic = sig
     properties ->
     int * int ->
     (properties -> int * int -> bool) ->
+    (properties -> move -> bool) ->
     move list
 end
 


### PR DESCRIPTION
The move checker is applied to every legal move when the king is in check. It works by making the move on a new board, calculating the legal moves for the opponent in that position, and then checking whether our king is attacked or not. Only those moves that do not place our king in check are legal.

The reason I only need to check these moves when we are in check is that I already do the pin check at the start. Therefore, I can assume that the piece is not pinned. If a piece is not pinned and the king is not in check, then that piece can move where ever it wants because there is no way it can put the king in danger.

I applied it to the knight as an example.