### PR TITLE
Implements update_board and Pawn logic

### DIFF
--- a/src/game.ml
+++ b/src/game.ml
@@ -60,34 +60,18 @@ let update_board (bd : t) (((old_x, old_y), (new_x, new_y)) : move) : t
       && new_y - old_y = -1
     then board_arr.(new_x + (new_x - old_x)).(new_y + 1) <- None;
     (* Check if castling just occurred *)
-    (* White King castling right *)
+    (* Rightside castle *)
     if
-      old_piece = Some (White, King)
-      && new_y = 0 && old_y = 0
+      (old_piece = Some (White, King) || old_piece = Some (Black, King))
       && new_x - old_x = 2
-      && board_arr.(7).(0) = Some (White, Rook)
-    then board_arr.(5).(0) <- Some (White, Rook);
-    (* White King castling left *)
+    then board_arr.(new_x - 1).(new_y) <- board_arr.(7).(new_y);
+    board_arr.(7).(new_y) <- None;
+    (* Leftside castle *)
     if
-      old_piece = Some (White, King)
-      && new_y = 0 && old_y = 0
+      (old_piece = Some (White, King) || old_piece = Some (Black, King))
       && new_x - old_x = -2
-      && board_arr.(0).(0) = Some (White, Rook)
-    then board_arr.(3).(0) <- Some (White, Rook);
-    (* Black king castling right (from White's POV) *)
-    if
-      old_piece = Some (Black, King)
-      && new_y = 7 && old_y = 7
-      && new_x - old_x = 2
-      && board_arr.(7).(7) = Some (Black, Rook)
-    then board_arr.(5).(7) <- Some (Black, Rook);
-    (* Black king castling left (from White's POV) *)
-    if
-      old_piece = Some (Black, King)
-      && new_y = 7 && old_y = 7
-      && new_x - old_x = -2
-      && board_arr.(0).(7) = Some (Black, Rook)
-    then board_arr.(3).(7) <- Some (Black, Rook)
+    then board_arr.(new_x + 1).(new_y) <- board_arr.(0).(new_y);
+    board_arr.(0).(new_y) <- None
   in
   check_conditions;
   let output_board = array_to_board board_arr in


### PR DESCRIPTION
Adding code for Pawn is difficult for many reasons compared to the other soldiers. The direction of travel depends on the color, not to mention that it can sometimes move forward two spaces if it is in the starting position and nothing is ahead of it. 

Here is a breakdown of my edits:

update_board:
- Updates board according to the last move with three special edge cases:
1) Checking if a Pawn is at either end and making it a Queen
2) Checking if an Pawn en passant move just occurred so as to remove the piece below it
3) Updating the King and Rook during a castle move

Pawn:
- Checks for the potential moves forward for a White Pawn and another List filter if it is a Black Pawn
- A Pawn needs to check for the en passant edge case, which I have added by checking for if it happens to the right of the looked-at Pawn

Let me know if you have any questions. 