### PR TITLE
Forgot enemy find thing

### DIFF
--- a/src/game.ml
+++ b/src/game.ml
@@ -271,11 +271,12 @@ end
 module Bishop : SoldierLogic = struct
   let legal_moves (prop : properties) (x, y) move_checker : move list =
     let board = board_to_array prop.board in
+    let ef = prop.enemy_find in
     let square_list =
-      build_line (x + 1, y + 1) board 1 1 prop.color
-      @ build_line (x - 1, y + 1) board (-1) 1 prop.color
-      @ build_line (x + 1, y - 1) board 1 (-1) prop.color
-      @ build_line (x - 1, y - 1) board (-1) (-1) prop.color
+      build_line (x + 1, y + 1) board 1 1 prop.color ef
+      @ build_line (x - 1, y + 1) board (-1) 1 prop.color ef
+      @ build_line (x + 1, y - 1) board 1 (-1) prop.color ef
+      @ build_line (x - 1, y - 1) board (-1) (-1) prop.color ef
     in
     let moves = squares_to_moves (x, y) square_list in
     List.filter (move_checker prop) moves
@@ -284,11 +285,12 @@ end
 module Rook : SoldierLogic = struct
   let legal_moves (prop : properties) (x, y) move_checker : move list =
     let board = board_to_array prop.board in
+    let ef = prop.enemy_find in
     let square_list =
-      build_line (x + 1, y) board 1 0 prop.color
-      @ build_line (x - 1, y) board (-1) 0 prop.color
-      @ build_line (x, y + 1) board 0 1 prop.color
-      @ build_line (x, y - 1) board 0 (-1) prop.color
+      build_line (x + 1, y) board 1 0 prop.color ef
+      @ build_line (x - 1, y) board (-1) 0 prop.color ef
+      @ build_line (x, y + 1) board 0 1 prop.color ef
+      @ build_line (x, y - 1) board 0 (-1) prop.color ef
     in
     let moves = squares_to_moves (x, y) square_list in
     List.filter (move_checker prop) moves

--- a/src/helper.ml
+++ b/src/helper.ml
@@ -57,8 +57,13 @@ let rec get_targets = function
   | [] -> []
   | h :: t -> snd h :: get_targets t
 
-(** [build_line (x,y) board_arr dirx diry color] returns a list of valid
-    squares in a single direction that a soldier can move to. *)
+(** [build_line (x,y) board_arr dirx diry color ef] returns a list of
+    valid squares in a single direction that a soldier can move to. If
+    moving in that direction hits a wall, the last square is before the
+    wall. If it hits a same color piece, then the last square is before
+    that piece. If it hits a different color piece, then that piece is
+    the last square. If [ef] is true, then same color pieces will be
+    included in the last square.*)
 let rec build_line (x, y) board_arr dirx diry color ef =
   if not (on_board (x, y)) then []
   else

--- a/src/helper.ml
+++ b/src/helper.ml
@@ -59,14 +59,15 @@ let rec get_targets = function
 
 (** [build_line (x,y) board_arr dirx diry color] returns a list of valid
     squares in a single direction that a soldier can move to. *)
-let rec build_line (x, y) board_arr dirx diry color =
+let rec build_line (x, y) board_arr dirx diry color ef =
   if not (on_board (x, y)) then []
   else
     match board_arr.(x).(y) with
     | None ->
         (x, y)
-        :: build_line (x + dirx, y + diry) board_arr dirx diry color
-    | Some (piece_color, _) when piece_color = color -> []
+        :: build_line (x + dirx, y + diry) board_arr dirx diry color ef
+    | Some (piece_color, _) when piece_color = color ->
+        if ef then [ (x, y) ] else []
     | Some (_, _) -> [ (x, y) ]
 
 (** [get_piece_moves piece_pos lst] is a list of all the moves in the


### PR DESCRIPTION
Forgot to add enemy find properties to bishop and rook legal moves. Basically, if enemy find is true, then allow legal moves to same color pieces so we can protect our own pieces and not have the king take them.