### PR TITLE
Move checker for king movement, general cleanup

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -25,8 +25,7 @@ let input_to_move str : move =
 
 (** [is_checkmate st] is true if [st] is currently in checkmate. A state
     is in checkmate if it has no legal moves and its king is in check. *)
-let is_checkmate st =
-  List.length st.moves = 0 && st.game_state.king_in_check
+let is_checkmate st = List.length st.moves = 0 && st.king_in_check
 
 (** [play_game state black result] prompts the player and handles
     white's [state] in the current game. If [result] specifies a color,
@@ -43,10 +42,10 @@ let rec play_game state black result =
   pretty_print state.game_state.board;
   match result with
   | Some White ->
-      print_endline "\n Checkmate! You win.";
+      print_endline "\nCheckmate! You win.";
       exit 0
   | Some Black ->
-      print_endline "\n Checkmate! You Lose.";
+      print_endline "\nCheckmate! You Lose.";
       exit 0
   | None -> (
       print_endline ("\n" ^ pp_move_list state.moves);

--- a/src/boards.ml
+++ b/src/boards.ml
@@ -26,13 +26,11 @@ let starting_board : Game.t =
   ]
 
 let starting_board_init_moves : move list = 
-  [
-  ((1, 0), (2, 2));
-  ((1, 0), (0, 2));
-  ((6, 0), (7, 2));
-  ((6, 0), (5, 2));
-  (*add more here for pawns*)
-]
+  [((0, 1), (0, 3)); ((0, 1), (0, 2)); ((1, 0), (2, 2)); ((1, 0), (0, 2)); 
+  ((1, 1), (1, 3)); ((1, 1), (1, 2)); ((2, 1), (2, 3)); ((2, 1), (2, 2)); 
+  ((3, 1), (3, 3)); ((3, 1), (3, 2)); ((4, 1), (4, 3)); ((4, 1), (4, 2)); 
+  ((5, 1), (5, 3)); ((5, 1), (5, 2)); ((6, 0), (7, 2)); ((6, 0), (5, 2)); 
+  ((6, 1), (6, 3)); ((6, 1), (6, 2)); ((7, 1), (7, 3)); ((7, 1), (7, 2))]
 
 let empty_with_piece piece : Game.t = 
   [
@@ -58,7 +56,7 @@ let knight_board : Game.t =
     [ None; None; None; None; None; None; None; None;];
   ]
 
-let king_board : Game.t = 
+let king_board1 : Game.t = 
   [
     [ None; None; None; None; None; None; None; None;];
     [ None; None; None; None; None; None; None; None;];
@@ -71,6 +69,42 @@ let king_board : Game.t =
   ]
 let king_board_enemy_moves : move list = 
   squares_to_moves (4, 0) [(4, 1); (4, 2); (4, 3); (4, 4); (4, 5); (4, 6); (4, 7); ]   
+
+let king_board2 : Game.t = 
+  [
+    [ None; None; None; None; None; None; None; None;];
+    [ None; None; None; None; None; None; None; None;];
+    [ Some (White, King); None; None; None; None; None; None; None;];
+    [ None; None; None; None; None; None; None; None;];
+    [ Some (White, Rook); None; None; None; None; Some (Black, King); None; None;];
+    [ None; None; None; None; None; None; None; None;];
+    [ None; None; None; None; None; None; None; None;];
+    [ None; None; None; None; None; None; None; None;];
+  ]
+  
+let king_board3 : Game.t = 
+  [
+    [ None; None; None; None; None; None; None; None;];
+    [ None; None; None; None; None; None; None; None;];
+    [ Some (White, King); None; None; None; None; None; None; None;];
+    [ None; None; None; None; None; None; None; None;];
+    [ None; None; None; Some (White, Pawn); None; Some (Black, King); None; None;];
+    [ None; None; None; None; None; None; None; None;];
+    [ None; None; None; None; None; None; None; None;];
+    [ None; None; None; None; None; None; None; None;];
+  ]
+
+let king_board4 : Game.t = 
+  [
+    [ None; None; None; None; None; None; None; None;];
+    [ None; None; None; None; None; None; None; None;];
+    [ Some (White, King); None; None; None; None; None; None; None;];
+    [ None; None; None; None; Some (White, Rook); None; None; None;];
+    [ None; None; None; None; None; Some (Black, King); None; None;];
+    [ None; None; Some (White, Bishop); None; None; None; None; None;];
+    [ None; None; None; None; None; None; None; None;];
+    [ None; None; None; None; None; None; None; None;];
+  ]
 
 let move_checker_board1 : Game.t = 
   [

--- a/src/game.mli
+++ b/src/game.mli
@@ -32,16 +32,8 @@ type properties = {
   color : color;
   (*The last move played on this board.*)
   last_move : move;
-  (*The opponent's legal moves in the current position, including to
-    same color squares.*)
-  enemy_moves : move list;
-  (*True if this is finding the moves of the opponent, meaning squares
-    with same color pieces are now legal.*)
-  enemy_find : bool;
   (*The current position of this color's king.*)
   king_pos : int * int;
-  (*True if the king is attacked in the current position.*)
-  king_in_check : bool;
   (*True if the king can castle kingside in the current position.*)
   kingside_castle : bool;
   (*True if the king can castle queenside in the current position.*)

--- a/src/helper.ml
+++ b/src/helper.ml
@@ -18,20 +18,19 @@ let array_to_board board_arr =
 (** [on_board (x, y)] is true if [x] and [y] are in 0..7 inclusive. *)
 let on_board (x, y) = x >= 0 && x <= 7 && y >= 0 && y <= 7
 
-(** [same_color (x, y) board color ef] is true if the piece at [(x, y)]
-    is the same color as [color]. Requires: [(x, y)] is a coordinate on
-    the board. If [ef] is true, then this is always false.*)
+(** [same_color (x, y) board color] is true if the piece at [(x, y)] is
+    the same color as [color]. Requires: [(x, y)] is a coordinate on the
+    board.*)
 let same_color (x, y) board color =
   match board.(x).(y) with
   | None -> false
   | Some (piece_color, _) -> piece_color = color
 
-(** [is_valid_square coords board color ef] is true if [coords] is a
-    valid square that a piece can move to. A square is considered valid
-    if it is on the board and the piece existing at [coords] is not the
-    same color as [color]. If [ef] is true, then squares containing
-    pieces of the same color are valid. Requires: [board] is the array
-    version of the board. *)
+(** [is_valid_square coords board color] is true if [coords] is a valid
+    square that a piece can move to. A square is considered valid if it
+    is on the board and the piece existing at [coords] is not the same
+    color as [color]. Requires: [board] is the array version of the
+    board. *)
 let is_valid_square board color coords =
   on_board coords && not (same_color coords board color)
 
@@ -47,13 +46,12 @@ let rec get_targets = function
   | [] -> []
   | h :: t -> snd h :: get_targets t
 
-(** [build_line (x,y) board_arr dirx diry color ef] returns a list of
-    valid squares in a single direction that a soldier can move to. If
-    moving in that direction hits a wall, the last square is before the
-    wall. If it hits a same color piece, then the last square is before
-    that piece. If it hits a different color piece, then that piece is
-    the last square. If [ef] is true, then same color pieces will be
-    included in the last square.*)
+(** [build_line (x,y) board_arr dirx diry color] returns a list of valid
+    squares in a single direction that a soldier can move to. If moving
+    in that direction hits a wall, the last square is before the wall.
+    If it hits a same color piece, then the last square is before that
+    piece. If it hits a different color piece, then that piece is the
+    last square.*)
 let rec build_line (x, y) board_arr dirx diry color =
   if not (on_board (x, y)) then []
   else

--- a/src/helper.ml
+++ b/src/helper.ml
@@ -21,12 +21,10 @@ let on_board (x, y) = x >= 0 && x <= 7 && y >= 0 && y <= 7
 (** [same_color (x, y) board color ef] is true if the piece at [(x, y)]
     is the same color as [color]. Requires: [(x, y)] is a coordinate on
     the board. If [ef] is true, then this is always false.*)
-let same_color (x, y) board color ef =
-  if ef then false
-  else
-    match board.(x).(y) with
-    | None -> false
-    | Some (piece_color, _) -> piece_color = color
+let same_color (x, y) board color =
+  match board.(x).(y) with
+  | None -> false
+  | Some (piece_color, _) -> piece_color = color
 
 (** [is_valid_square coords board color ef] is true if [coords] is a
     valid square that a piece can move to. A square is considered valid
@@ -34,8 +32,8 @@ let same_color (x, y) board color ef =
     same color as [color]. If [ef] is true, then squares containing
     pieces of the same color are valid. Requires: [board] is the array
     version of the board. *)
-let is_valid_square board color ef coords =
-  on_board coords && not (same_color coords board color ef)
+let is_valid_square board color coords =
+  on_board coords && not (same_color coords board color)
 
 (** [squares_to_moves squares first] returns a list of moves starting at
     [start] and targeting each square in [squares].*)
@@ -56,15 +54,14 @@ let rec get_targets = function
     that piece. If it hits a different color piece, then that piece is
     the last square. If [ef] is true, then same color pieces will be
     included in the last square.*)
-let rec build_line (x, y) board_arr dirx diry color ef =
+let rec build_line (x, y) board_arr dirx diry color =
   if not (on_board (x, y)) then []
   else
     match board_arr.(x).(y) with
     | None ->
         (x, y)
-        :: build_line (x + dirx, y + diry) board_arr dirx diry color ef
-    | Some (piece_color, _) when piece_color = color ->
-        if ef then [ (x, y) ] else []
+        :: build_line (x + dirx, y + diry) board_arr dirx diry color
+    | Some (piece_color, _) when piece_color = color -> []
     | Some (_, _) -> [ (x, y) ]
 
 (** [get_piece_moves piece_pos lst] is a list of all the moves in the

--- a/src/state.ml
+++ b/src/state.ml
@@ -5,7 +5,9 @@ open Boards
 type t = {
   game_state : Game.properties;
   moves : Game.move list;
+  enemy_moves : Game.move list;
   turn : bool;
+  king_in_check : bool;
   a_rook_moved : bool;
   h_rook_moved : bool;
   king_moved : bool;
@@ -17,10 +19,7 @@ let init_state (board : Game.t) (color : Game.color) : t =
       board = starting_board;
       color;
       last_move = ((-1, -1), (-1, -1));
-      enemy_moves = [];
-      enemy_find = false;
       king_pos = (if color = White then (4, 0) else (4, 7));
-      king_in_check = false;
       kingside_castle = false;
       queenside_castle = false;
     }
@@ -32,7 +31,9 @@ let init_state (board : Game.t) (color : Game.color) : t =
   {
     game_state = init_properties;
     moves = init_moves;
+    enemy_moves = [];
     turn = init_turn;
+    king_in_check = false;
     a_rook_moved = false;
     h_rook_moved = false;
     king_moved = false;
@@ -42,17 +43,14 @@ let init_state (board : Game.t) (color : Game.color) : t =
     opponent with the opposite color of [our_color] and board [bd]. The
     [last_move] and [king_pos] are populated with [(-1, -1)], which
     signify that they should be disregarded. [enemy_moves] is the empty
-    list to allow free range of the enemy king. [king_in_check],
-    [queenside_castle], and [kingside_castle] are all false.*)
+    list to allow free range of the enemy king. [queenside_castle] and
+    [kingside_castle] are all false.*)
 let enemy_properties bd our_color =
   {
     board = bd;
     color = (if our_color = White then Black else White);
     last_move = ((-1, -1), (-1, -1));
-    enemy_moves = [];
-    enemy_find = true;
     king_pos = (-1, -1);
-    king_in_check = false;
     queenside_castle = false;
     kingside_castle = false;
   }
@@ -105,6 +103,8 @@ let play_move (st : t) ((oldx, oldy), (newx, newy)) : t =
   {
     game_state = new_properties;
     moves = [];
+    enemy_moves = [];
+    king_in_check = false;
     a_rook_moved = new_a_rook_moved;
     h_rook_moved = new_h_rook_moved;
     king_moved = new_king_moved;
@@ -123,8 +123,6 @@ let receive_move (st : t) (mv : move) : t =
       st.game_state with
       board = new_board;
       last_move = mv;
-      enemy_moves = new_enemy_moves;
-      king_in_check = new_king_in_check;
       queenside_castle = false (*TODO*);
       kingside_castle = false (*TODO*);
     }
@@ -134,5 +132,7 @@ let receive_move (st : t) (mv : move) : t =
     st with
     game_state = new_properties;
     moves = new_moves;
+    enemy_moves = new_enemy_moves;
     turn = true;
+    king_in_check = new_king_in_check;
   }

--- a/src/state.mli
+++ b/src/state.mli
@@ -2,18 +2,24 @@
 
     This module represents the state of a game of chess as it is being
     played, including the player's current chess position, their legal
-    moves, the properties of their position, and functions that update
-    their state upon a new move from this player or their opponent. *)
+    moves, the pseudo-legal enemy moves, the properties of their
+    position, and functions that update their state upon a new move from
+    this player or their opponent. *)
 
 type t = {
   (*The board with all of the pieces and properties.*)
   game_state : Game.properties;
   (*The legal moves on the pieces in the board for this color.*)
   moves : Game.move list;
+  (*The pseudo-legal moves of the opponent in the current position (king
+    independent).*)
+  enemy_moves : Game.move list;
   (*Players can only make a move if turn is true? After a move is
     played, we set this to false, and back to true when we receive a
     move from the opponent.*)
   turn : bool;
+  (*True if the king is attacked in the current position.*)
+  king_in_check : bool;
   (*True if the starting rook on the A file has moved.*)
   a_rook_moved : bool;
   (*True if the starting rook on the H file has moved.*)


### PR DESCRIPTION
- There was a bug with king movement where a king was allowed to move in line of a rook/queen/bishop to a farther square because that square wasn't seen as attacked since the king was in the way. This is the fix:
- I didn't realize it was much better to use the move checker with the king then to find pseudo-legal moves with weird edge cases and checking against those. Cleans up a lot of the code. Now, enemy_moves is only needed in state for castling detection. 
- Moved king_in_check to state because that's the only place we need it.
- Added more king tests.
- General cleanup.